### PR TITLE
Log table is now related to Session instead of Document (#66)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ _cache/
 .pytest_cache/
 
 sandbox/
+**/app.log

--- a/cranio/database.py
+++ b/cranio/database.py
@@ -74,6 +74,10 @@ def session_scope(engine=None):
 class InstanceBase:
 
     @classmethod
+    def get_instance(cls):
+        return cls.instance_id
+
+    @classmethod
     def reset_instance(cls):
         cls.instance_id = None
 
@@ -170,8 +174,8 @@ class Log(Base):
     ''' Software log table '''
     __tablename__ = 'fact_log'
     log_id = Column(Integer, primary_key=True, autoincrement=True)
-    document_id = Column(String, ForeignKey('dim_document.document_id'))
-    created_at = Column(DateTime, nullable=False, comment='Log entry date and time')
+    session_id = Column(String, ForeignKey('dim_session.session_id'), nullable=False)
+    created_at = Column(DateTime, nullable=False, comment='Log entry date and time with second precision (UTC+0)')
     logger = Column(String, nullable=False, comment='Name of the logger')
     level = Column(Integer, ForeignKey('dim_log_level.level'), nullable=False)
     trace = Column(String, comment='Error traceback')

--- a/cranio/handler.py
+++ b/cranio/handler.py
@@ -1,8 +1,8 @@
 import logging
 import traceback
-from datetime import datetime
+from datetime import datetime, timedelta
 from cranio import DEFAULT_DATEFMT
-from cranio.database import Log, session_scope, Document
+from cranio.database import Log, session_scope, Session
 
 
 class DatabaseHandler(logging.Handler):
@@ -12,8 +12,9 @@ class DatabaseHandler(logging.Handler):
         exc = record.__dict__['exc_info']
         if exc:
             trace = traceback.format_exc(exc)
-        dt = datetime.strptime(record.__dict__['asctime'], DEFAULT_DATEFMT)
+        dt = datetime.strptime(record.__dict__['asctime'], DEFAULT_DATEFMT) + \
+             timedelta(milliseconds=record.__dict__['msecs'])
         log = Log(logger=record.__dict__['name'], level=record.__dict__['levelno'],
-                  created_at=dt, trace=trace, message=record.__dict__['msg'], document_id=Document.instance_id)
+                  created_at=dt, trace=trace, message=record.__dict__['msg'], session_id=Session.get_instance())
         with session_scope() as s:
             s.add(log)

--- a/cranio/utils.py
+++ b/cranio/utils.py
@@ -1,4 +1,5 @@
 import os
+import time
 import logging
 import random
 from contextlib import suppress
@@ -7,6 +8,11 @@ from typing import Union
 from ruamel import yaml
 
 DEFAULT_LOGGING_CONFIG_PATH = Path(__file__).parent.parent / 'logging_config.yml'
+
+
+class UTCFormatter(logging.Formatter):
+    """ Logging formatter that converts timestamps to UTC+0 """
+    converter = time.gmtime
 
 
 def try_remove(name: Union[str, Path]):
@@ -29,7 +35,7 @@ def get_logging_levels() -> dict:
     return logging._levelToName
 
 
-def level_to_name(level: int) -> str:
+def log_level_to_name(level: int) -> str:
     return logging._levelToName[level]
 
 

--- a/logging_config.yml
+++ b/logging_config.yml
@@ -1,9 +1,7 @@
 version: 1
 formatters:
   default:
-    format: '%(asctime)s.%(msecs)03d;%(name)s;%(threadName)s;%(levelname)s;%(message)s'
-    datefmt: '%Y-%m-%d %H:%M:%S'
-  long:
+    class: cranio.utils.UTCFormatter
     format: '%(asctime)s.%(msecs)03d;%(name)s;%(threadName)s;%(levelname)s;%(message)s'
     datefmt: '%Y-%m-%d %H:%M:%S'
 handlers:
@@ -15,14 +13,14 @@ handlers:
   file:
     class: logging.handlers.RotatingFileHandler
     level: DEBUG
-    formatter: long
+    formatter: default
     filename: app.log
     maxBytes: 100000
     backupCount: 3
   database:
     class: cranio.handler.DatabaseHandler
     level: NOTSET
-    formatter: long
+    formatter: default
 loggers:
   cranio:
     level: DEBUG

--- a/test/test_database_handler.py
+++ b/test/test_database_handler.py
@@ -1,5 +1,5 @@
 import logging
-from cranio.utils import level_to_name
+from cranio.utils import log_level_to_name
 from cranio.database import session_scope, Log
 
 
@@ -11,5 +11,5 @@ def test_database_handler(database_document_fixture):
         assert len(logs) == 1
         log = logs[0]
         assert log.message == 'foo'
-        assert level_to_name(log.level) == 'INFO'
+        assert log_level_to_name(log.level) == 'INFO'
         assert log.logger == 'cranio'

--- a/test/test_log_data_model.py
+++ b/test/test_log_data_model.py
@@ -1,0 +1,39 @@
+import pytest
+import logging
+import time
+from sqlalchemy.exc import IntegrityError
+from cranio.core import timestamp
+from cranio.utils import log_level_to_name
+from cranio.database import init_database, Log, session_scope, Session
+
+logger_name = 'cranio'
+logger = logging.getLogger(logger_name)
+
+
+def test_logging_fails_if_no_session_is_initialized():
+    # initialize database but session uninitialized
+    init_database()
+    with pytest.raises(IntegrityError):
+        logger.info('This should raise an IntegrityError')
+
+
+def test_logging_is_directed_to_database_log_table_with_correct_values(database_fixture):
+    wait_duration = 0.01 # seconds
+    t_start = timestamp()
+    # short wait to ensure that t_start < log timestamp
+    time.sleep(wait_duration)
+    msg = 'This should not raise an IntegrityError'
+    logger.info(msg)
+    # short wait to ensure that t_stop > log timestamp
+    time.sleep(wait_duration)
+    t_stop = timestamp()
+    with session_scope() as s:
+        logs = s.query(Log).all()
+        assert len(logs) == 1
+        log = logs[0]
+        assert log.message == msg
+        assert log.session_id == Session.get_instance()
+        assert log.logger == logger_name
+        assert log_level_to_name(log.level).lower() == 'info'
+        # verify that the log entry is created between t_start and current time
+        assert t_start <= log.created_at <= t_stop


### PR DESCRIPTION
* Change logging datetime format to UTC+0 with UTCFormatter class
* Add get_instance classmethod to InstanceBase
* Change DatabaseHandler now adds milliseconds to asctime
* Change function name level_to_name to log_level_to_name